### PR TITLE
CI: mypy를 포함한 몇몇 linter들을 추가합니다

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,63 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+    python: python3.11
+default_stages: [pre-commit, pre-push]
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    - id: check-json
+    - id: check-toml
+    - id: check-xml
+    - id: check-yaml
+    - id: check-added-large-files
+    - id: detect-aws-credentials
+    - id: detect-private-key
+    - id: end-of-file-fixer
+    - id: mixed-line-ending
+    - id: pretty-format-json
+    - id: trailing-whitespace
+      exclude_types:
+        - javascript
+        - markdown
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+    - id: flake8
+      additional_dependencies:
+        - flake8-bugbear
+        - flake8-noqa
+      args:
+      - --max-line-length=120
+      - --max-complexity=18
+-   repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+    - id: black
+      language_version: python3.11
+      args:
+        - --line-length=120
+-   repo: https://github.com/PyCQA/bandit
+    rev: '1.7.8'
+    hooks:
+    - id: bandit
+-   repo: https://github.com/PyCQA/isort
+    rev: '5.13.2'
+    hooks:
+      - id: isort
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.9.0'
+    hooks:
+      - id: mypy
+        args:
+          - --no-strict-optional
+          - --ignore-missing-imports
+          - --check-untyped-defs
+          - --disallow-untyped-defs
+          - --disallow-incomplete-defs
+          - --disallow-untyped-calls
+-   repo: https://github.com/dosisod/refurb
+    rev: v2.0.0
+    hooks:
+      - id: refurb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Devtools
+hooks-install:
+	poetry run pre-commit install
+
+hooks-upgrade:
+	poetry run pre-commit autoupdate
+
+hooks-lint:
+	poetry run pre-commit run --all-files
+
+lint: hooks-lint  # alias
+
+hooks-mypy:
+	poetry run pre-commit run mypy --all-files
+
+mypy: hooks-mypy  # alias

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+# Setup development environment
+setup:
+	poetry install
+
 # Devtools
-hooks-install:
+hooks-install: setup
 	poetry run pre-commit install
 
 hooks-upgrade:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# PyCon Korea API Server (2024 ~)
+
+## 1. 로컬 개발 환경 설정
+본 프로젝트는 Python3.11 (또는 이후 버전)과 Poetry를 사용합니다.
+- Poetry 설치는 [여기](https://python-poetry.org/docs/)에서 확인해주세요.
+
+### 1.1. 프로젝트 설치
+```bash
+poetry install
+```
+
+### 1.2. pre-commit hook 설정
+본 프로젝트에서는 코딩 컨벤션을 준수하기 위해 [pre-commit](https://pre-commit.com/)을 사용합니다.  
+pre-commit을 설치하려면 다음을 참고해주세요.
+
+#### 1.2.1. Linux / macOS
+```bash
+# 설치
+make hooks-install
+
+# 프로젝트 전체 코드 lint 검사 & format
+make lint
+
+# 프로젝트 전체 코드에 대해 mypy 타입 검사
+make mypy
+```
+
+#### 1.2.2. Windows
+```bash
+# 설치
+poetry run pre-commit install
+
+# 프로젝트 전체 코드 lint 검사 & format
+poetry run pre-commit run --all-files
+
+# 프로젝트 전체 코드에 대해 mypy 타입 검사
+poetry run pre-commit run mypy --all-files
+```

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pyconkr.settings")
     try:

--- a/pyconkr/settings.py
+++ b/pyconkr/settings.py
@@ -20,12 +20,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-kjtg@&v106jt2wz9tlci@b!3uqrig7eud^3zk53&!me@gw_(q@"
+SECRET_KEY = "django-insecure-kjtg@&v106jt2wz9tlci@b!3uqrig7eud^3zk53&!me@gw_(q@"  # nosec: B105
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: list[str] = []
 
 
 # Application definition
@@ -54,8 +54,7 @@ ROOT_URLCONF = "pyconkr.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR / 'templates']
-        ,
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/pyconkr/urls.py
+++ b/pyconkr/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 


### PR DESCRIPTION
## 주요 변경 사항
- 아래 linter들을 추가합니다.
  - [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks)
    - check-json / check-toml / check-xml / check-yaml : JSON / TOML / XML / YAML lint
    - check-added-large-files : 너무 큰 파일이 커밋되는 것을 방지
    - detect-aws-credentials / detect-private-key : AWS 등의 인증 정보 감지
    - end-of-file-fixer : 파일 끝에 개행 문자 추가
    - mixed-line-ending : CRLF / LF 혼용 감지 (Windows / Unix 호환성)
    - pretty-format-json : JSON prettify
    - trailing-whitespace : 라인 끝의 공백을 제거
  - [flake8](https://github.com/PyCQA/flake8) : 코드 스타일 검사
  - [black](https://github.com/psf/black) : 코드 포매팅 검사
  - [Bandit](https://github.com/PyCQA/bandit) : 코드 내의 보안 이슈를 검사
  - [isort](https://github.com/PyCQA/isort) : 코드 내의 import 문들을 정리 (순서대로 정렬하는 등...)
  - [mypy](https://github.com/python/mypy) : 코드 내의 타입을 검사해서 발생할 수 있는 이슈를 잡아냄
  - [Refurb](https://github.com/dosisod/refurb) : 비효율적이거나 오래된 관습적인 코드를 잡아냄

- pre-commit shortcut을 위한 Makefile을 추가합니다.
  - `make lint`, `make mypy`, `make hooks-upgrade` 등으로 사용하실 수 있어요!

## 추가 사항
- 아직 #1 이 머지되지 않아, diff를 적게 표시하기 위해 add-poetry 브랜치를 base 브랜치로 지정합니다.
  요건 PR 머지 시 main으로 변경할게요!